### PR TITLE
bump django up to 1.11.23

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ click==6.7                # via click-log, edx-lint, pip-tools
 configparser==3.5.0       # via pydocstyle, pylint
 diff-cover==1.0.4
 distlib==0.2.7            # via caniusepython3
-django==1.11.14
+django==1.11.23
 edx-i18n-tools==0.4.7
 edx-lint==0.5.5
 enum34==1.1.6             # via astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -11,7 +11,7 @@ certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cmarkgfm
 chardet==3.0.4            # via doc8, requests
 cmarkgfm==0.4.2           # via readme-renderer
-django==1.11.14
+django==1.11.23
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.3.0


### PR DESCRIPTION
only used for dev/unit testing, but this should clear out a security warning. Dependabot has been making PRs to address this but pulling in lots of other changes to the requirements at the same time. This one should just make the security warning go away.