### PR TITLE
pin pip version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
   - pip
   
 before_install:
-  - pip install --upgrade pip
+  - pip install --upgrade pip==20.0.1
 
 install:
   - pip install -r requirements/travis.txt


### PR DESCRIPTION
Attempting to work around a bug on recent travis builds.

TravisCI builds in the last few weeks have been failing to install requirements with:

```
    from pip._internal.download import PipSession
263ImportError: No module named download
```

Eg: https://travis-ci.org/appsembler/appsembler-credentials-extensions/builds/636560663

Even re-running the build on PRs that had previously been passing now fails. I don't know exactly what's going on, but it appears to have been introduced with pip 20.0.2. For now, the easiest fix is to pin pip to the previous version, which appears to fix it. We can test again when a new version of pip comes out.